### PR TITLE
Fix Tool Keys and Keymasks

### DIFF
--- a/SketchUp/Sketchup/Tool.rb
+++ b/SketchUp/Sketchup/Tool.rb
@@ -27,9 +27,9 @@
 #
 # - +CONSTRAIN_MODIFIER_KEY+ = Shift Key
 # - +CONSTRAIN_MODIFIER_MASK+ = Shift Key
-# - +COPY_MODIFIER_KEY+ = Menu on Mac, Ctrl on PC
-# - +COPY_MODIFIER_MASK+ = Alt on Mac, Ctrl on PC
-# - +ALT_MODIFIER_KEY+ = Command on Mac, Menu on PC
+# - +COPY_MODIFIER_KEY+ = Alt/Option on Mac, Ctrl on PC
+# - +COPY_MODIFIER_MASK+ = Alt/Option on Mac, Ctrl on PC
+# - +ALT_MODIFIER_KEY+ = Command on Mac, Alt on PC
 # - +ALT_MODIFIER_MASK+ = Command on Mac, Alt on PC
 #
 # @version SketchUp 6.0


### PR DESCRIPTION
This is the first time ever I put something on GitHub myself so I hope I'm doing it right :O .

Fixed the descriptions of keys and keymasks constants to the Tool class. The Mac keys are based on SketchUp tool documentation as I don't have access to Mac myself.