### PR TITLE
update model return types

### DIFF
--- a/SketchUp/sketchup.rb
+++ b/SketchUp/sketchup.rb
@@ -48,7 +48,7 @@ module Sketchup
   #     # code acting on the model
   #   end
   #
-  # @return model - active model object if successful, false if
+  # @return [Sketchup::Model] model - active model object if successful, false if
   #   unsuccessful
   #
   # @version SketchUp 6.0


### PR DESCRIPTION
In rubymine, Sketchup.active_model.active_view, the `.active_view` can be autocompleted.