### PR TITLE
Fix order of subtraction

### DIFF
--- a/SketchUp/Sketchup/ComponentInstance.rb
+++ b/SketchUp/Sketchup/ComponentInstance.rb
@@ -460,8 +460,10 @@ class Sketchup::ComponentInstance < Sketchup::Drawingelement
   end
 
   # The subtract method is used to compute the boolean difference of the two
-  # instances representing manifold solid volumes (this - arg).  If the specified
-  # objects (this and arg) do not represent manifold volumes, this method fails.
+  # instances representing manifold solid volumes (arg - this).  Both instances
+  # are deleted and replaced by the result of subtracting the first from the
+  # second instance.  If the specified objects (this and arg) do not represent
+  # manifold volumes, this method fails.
   #
   # @example
   #   entities = Sketchup.active_model.entities
@@ -536,9 +538,10 @@ class Sketchup::ComponentInstance < Sketchup::Drawingelement
   end
 
   # The trim method is used to compute the (non-destructive) boolean difference
-  # of the two instances representing manifold solid volumes (this - arg).  If
-  # the specified objects (this and arg) do not represent manifold volumes, this
-  # method fails.
+  # of the two instances representing manifold solid volumes (arg - this).  The
+  # argument is deleted and replaced by the result of subtracting the first from
+  # the second instance.  If the specified objects (this and arg) do not represent
+  # manifold volumes, this method fails.
   #
   # @example
   #   entities = Sketchup.active_model.entities

--- a/SketchUp/Sketchup/Group.rb
+++ b/SketchUp/Sketchup/Group.rb
@@ -525,8 +525,10 @@ class Sketchup::Group < Sketchup::Drawingelement
   end
 
   # The subtract method is used to compute the boolean difference of the two
-  # groups representing manifold solid volumes (this - arg).  If the specified
-  # objects (this and arg) do not represent manifold volumes, this method fails.
+  # groups representing manifold solid volumes (arg - this).  Both groups are
+  # deleted and replaced by the result of subtracting the first from the second
+  # group.  If the specified objects (this and arg) do not represent manifold
+  # volumes, this method fails.
   #
   # @example
   #   entities = Sketchup.active_model.entities
@@ -640,9 +642,10 @@ class Sketchup::Group < Sketchup::Drawingelement
   end
 
   # The trim method is used to compute the (non-destructive) boolean difference
-  # of the two groups representing manifold solid volumes (this - arg).  If
-  # the specified objects (this and arg) do not represent manifold volumes, this
-  # method fails.
+  # of the two groups representing manifold solid volumes (arg - this).  The
+  # argument is deleted and replaced by the result of subtracting the first from
+  # the second group.  If the specified objects (this and arg) do not represent
+  # manifold volumes, this method fails.
   #
   # @example
   #   entities = Sketchup.active_model.entities


### PR DESCRIPTION
It was not clear to me what is subtracted from what, and which method (subtract/trim) is non-desctructive.
- Fix order of subtraction: When I subtract this from arg, it should equal `arg - this`
- documentation of side-effects which groups/instances are deleted (`#<Deleted Entity>`)